### PR TITLE
Add configurable parameters to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,22 @@ RUN apt-get update && apt-get install -y --force-yes --no-install-recommends \
 ADD etc /etc
 ADD opt /opt
 
+# The delay (in secons) between connections before the container is terminated
+ENV CONSOLE_TTL "3600"
+
+# X11VNC_CLIP: The area of the application to show
+ENV X11VNC_CLIP "4096x4096+0+21"
+# The name of the application to publish with X11VNC
+ENV X11VNC_NAME "iKVM Viewer"
+
+# The username to use when connecting to the BMC
+ENV IPMI_USERNAME "ADMIN"
+# The password to use when connecting to the BMC
+ENV IPMI_PASSWORD "ADMIN"
+
+# The address of the BMC to connect (MANDATORY)
+# Define with `docker run <image_name> -e IPMI_ADDRESS=<address>`
+#ENV IPMI_ADDRESS "192.0.2.10"
+
 EXPOSE 5900
 ENTRYPOINT ["/opt/kvm-console/bin/startup.sh"]

--- a/README.md
+++ b/README.md
@@ -6,17 +6,23 @@ kvm-console-supermicro
 
 This docker image provides standard VNC on Supermicro's BMC using its native iKVM Viewer.  The iKVM Viewer is downloaded at runtime from the BMC itself to avoid version mismatches.
 
+Configuration
+-------------
+
+The following settings are configurable using env variables:
+
+ - X11VNC_NAME: The name of the application to publish with X11VNC
+ - X11VNC_CLIP: The area of the application to show
+ - CONSOLE_TTL: The delay (in secons) between connections before the container
+                is terminated
+ - IPMI_USENAME: The username to use when connecting to the BMC
+ - IPMI_PASSWORD: The password to use when connecting to the BMC
+ - IPMI_ADDRESS: The address of the BMC to connect to (MANDATORY)
+
 Usage
 -----
 
-    $ docker build -t internap/kvm-console-supermicro .
-    Successfully built fdfff106efbe
-    $ docker run -d -t -i -e IPMI_ADDRESS=192.0.2.10 -e IPMI_USERNAME=username -e IPMI_PASSWORD=password --publish-all internap/kvm-console-supermicro
-    fc4644be6959404d6d65252bb5b5e6ea8edc0b2019e43447b6b36e06da4d6ec0
-    $ docker ps
-    CONTAINER ID        IMAGE                                    COMMAND                    CREATED             STATUS              PORTS                     NAMES
-    fc4644be6959        internap/kvm-console-supermicro:latest   "/opt/kvm-console/bi   6 seconds ago       Up 6 seconds        0.0.0.0:32780->5900/tcp   nostalgic_mayer     
-    $ vncviewer 127.0.0.1:32780
+    $ console-supermicro.sh 192.0.2.10 unsername password
 
 Contributing
 ============

--- a/etc/supervisor/conf.d/idle-timeout.conf
+++ b/etc/supervisor/conf.d/idle-timeout.conf
@@ -15,7 +15,7 @@
 [program:idle-timeout]
 priority=1
 directory=/
-command=/bin/bash -c 'sleep ${CONSOLE_TTL-"3600"}; supervisorctl shutdown'
+command=/bin/bash -c '[ "$CONSOLE_TTL" ] && sleep $CONSOLE_TTL && supervisorctl shutdown'
 user=root
 autostart=true
 stopsignal=KILL

--- a/etc/supervisor/conf.d/vnc-server.conf
+++ b/etc/supervisor/conf.d/vnc-server.conf
@@ -15,7 +15,7 @@
 [program:vnc-server]
 priority=20
 directory=/
-command=/opt/kvm-console/bin/vnc-server.sh java
+command=/opt/kvm-console/bin/vnc-server.sh
 user=kvm-console
 autostart=false
 autorestart=true

--- a/opt/kvm-console/bin/vnc-server.sh
+++ b/opt/kvm-console/bin/vnc-server.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-pid="$(pidof "$1")"
-[ "$pid" ]
-window_id=$(xdotool search --pid "$pid" --onlyvisible --limit 1 .+)
+window_id=$(xdotool search --name "$X11VNC_NAME")
+[ "$window_id" ]
 xdotool windowfocus "$window_id"
-x11vnc -display :1 -rfbport 5901 -xkb -shared -forever -id "$window_id" -clip 4096x4096+0+21 -desktop ""
+x11vnc -display :1 -rfbport 5901 -xkb -shared -forever \
+       -id "$window_id" -clip "$X11VNC_CLIP" -desktop ""


### PR DESCRIPTION
The following settings are now configurable using env variables:
- X11VNC_NAME: The name of the application to publish with X11VNC
- X11VNC_CLIP: The area of the application to show

The following settings are still configurable but default values are set in
Dockerfile:
- CONSOLE_TTL: The delay (in secons) between connections before the container
              is terminated
- IPMI_USENAME: The username to use when connecting to the BMC
- IPMI_PASSWORD: The password to use when connecting to the BMC

The following settings are mandatory and not default value is provided:
- IPMI_ADDRESS: The address of the BMC to connect to
