### PR TITLE
Support for splash screen image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,19 +18,23 @@ ENV HOME /root
 
 RUN apt-get update && apt-get install -y --force-yes --no-install-recommends \
     supervisor xinetd x11vnc xvfb xdotool x11-utils curl unzip openjdk-7-jre \
-    xmlstarlet \
+    xmlstarlet iptables xloadimage \
     && apt-get autoclean && apt-get autoremove && rm -rf /var/lib/apt/lists/*
 
 ADD etc /etc
 ADD opt /opt
 
-# The delay (in secons) between connections before the container is terminated
+# The delay (in seconds) between connections before the container is terminated
 ENV CONSOLE_TTL "3600"
 
 # X11VNC_CLIP: The area of the application to show
 ENV X11VNC_CLIP "4096x4096+0+21"
-# The name of the application to publish with X11VNC
-ENV X11VNC_NAME "iKVM Viewer"
+# Desktop title shown by X11VNC
+ENV X11VNC_TITLE ""
+# Image to show until we get the application working
+ENV SPLASH_IMAGE ""
+# Screen size to show until we get the application working
+ENV SPLASH_SIZE ""
 
 # The username to use when connecting to the BMC
 ENV IPMI_USERNAME "ADMIN"

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Configuration
 
 The following settings are configurable using env variables:
 
- - X11VNC_NAME: The name of the application to publish with X11VNC
  - X11VNC_CLIP: The area of the application to show
- - CONSOLE_TTL: The delay (in secons) between connections before the container
-                is terminated
+ - X11VNC_TITLE: Desktop title shown by X11VNC (default to "")
+ - SPLASH_IMAGE: Image to show until we get the application working
+ - SPLASH_SIZE: Screen size to show until we get the application working (default to splash image size or 1x1)
+ - CONSOLE_TTL: The delay (in seconds) between connections before the container is terminated
  - IPMI_USENAME: The username to use when connecting to the BMC
  - IPMI_PASSWORD: The password to use when connecting to the BMC
  - IPMI_ADDRESS: The address of the BMC to connect to (MANDATORY)

--- a/etc/supervisor/conf.d/kvm-console.conf
+++ b/etc/supervisor/conf.d/kvm-console.conf
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 [group:console]
-programs=x11-server,ikvm-viewer,ikvm-resize,vnc-server
+programs=x11-server,ikvm-viewer,vnc-export-app,vnc-server
 priority=999
 

--- a/etc/supervisor/conf.d/vnc-export-app.conf
+++ b/etc/supervisor/conf.d/vnc-export-app.conf
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[program:ikvm-resize]
+[program:vnc-export-app]
 priority=16
 directory=/home/kvm-console
-command=/opt/kvm-console/bin/ikvm-resize.sh
+command=/opt/kvm-console/bin/vnc-export-app.sh
 user=kvm-console
 autostart=false
 autorestart=true
 stopsignal=QUIT
 environment=DISPLAY=":1",HOME="/home/kvm-console"
-stdout_logfile=/var/log/ikvm-resize.log
+stdout_logfile=/var/log/vnc-export-app.log
 redirect_stderr=true
 stopsignal=KILL
 

--- a/opt/kvm-console/bin/vnc-export-app.sh
+++ b/opt/kvm-console/bin/vnc-export-app.sh
@@ -19,13 +19,18 @@ while true; do
     read winid width height < <(xwininfo -root -tree \
         | grep -iE 'Java iKVM Viewer.+Resolution' \
         | sed 's/^\(.*\)".*Resolution \([0-9]*\) X \([0-9]*\).*/\1 \2 \3/g')
+
     [ -z "$winid" ] && [ -z "$width" ] && [ -z "$height" ] && continue
+
     width=$((width + 4))
     height=$((height + 24))
     actual_width=$(x11vnc -query wdpy_x 2>/dev/null | cut -d':' -f 2)
     actual_height=$(x11vnc -query wdpy_y 2>/dev/null | cut -d':' -f 2)
+
     [ "$width" -eq "$actual_width" ] && [ "$height" -eq "$actual_height" ] && continue
-    xdotool windowsize $winid $(( width + 1 )) $(( height + 1 ))
-    sleep .1
+
+    xdotool windowfocus "$winid"
+    x11vnc -remote "id:$winid" --sync
+    x11vnc -remote "clip:$X11VNC_CLIP" --sync
     xdotool windowsize $winid $width $height
 done

--- a/opt/kvm-console/bin/vnc-server.sh
+++ b/opt/kvm-console/bin/vnc-server.sh
@@ -14,8 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-window_id=$(xdotool search --name "$X11VNC_NAME")
-[ "$window_id" ]
-xdotool windowfocus "$window_id"
-x11vnc -display :1 -rfbport 5901 -xkb -shared -forever \
-       -id "$window_id" -clip "$X11VNC_CLIP" -desktop ""
+splash_width=1
+splash_height=1
+
+read screen_width screen_height < <(xdotool getdisplaygeometry)
+
+if [ "${SPLASH_IMAGE-}" ]; then
+    read splash_width splash_height < <(\
+        xview -identify $SPLASH_IMAGE | \
+        sed 's/.* \([0-9]*\)x\([0-9]*\) .*/\1 \2/g')
+    xview -center -onroot $SPLASH_IMAGE
+fi
+
+if [ "${SPLASH_SIZE-}" ]; then
+    read splash_width splash_height < <(echo $SPLASH_SIZE | tr 'x' ' ')
+fi
+
+clip_x=$((screen_width/2-splash_width/2))
+clip_y=$((screen_height/2-splash_height/2))
+splash_clip=${splash_width}x${splash_height}+${clip_x}+${clip_y}
+
+exec x11vnc -rfbport 5901 -xkb -shared -forever -desktop "${X11VNC_TITLE-}" -clip $splash_clip


### PR DESCRIPTION
The following field was removed:
- X11VNC_NAME: This is irrelevant for now

The following fields were added:
- X11VNC_TITLE: Desktop title shown by X11VNC (default to "")
- SPLASH_IMAGE: Image to show until we get the application working
- SPLASH_SIZE: Screen size to show until we get the application working (default to splash image size or 1x1)
