### PR TITLE
Remove references to ikvm in services names

### DIFF
--- a/etc/supervisor/conf.d/kvm-console.conf
+++ b/etc/supervisor/conf.d/kvm-console.conf
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 [group:console]
-programs=x11-server,ikvm-viewer,vnc-export-app,vnc-server
+programs=x11-server,viewer-app,vnc-export-app,vnc-server
 priority=999
 

--- a/etc/supervisor/conf.d/viewer-app.conf
+++ b/etc/supervisor/conf.d/viewer-app.conf
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[program:ikvm-viewer]
+[program:viewer-app]
 priority=15
 directory=/home/kvm-console
-command=/bin/bash -c '/opt/kvm-console/bin/ikvm-viewer.sh $IPMI_ADDRESS $IPMI_USERNAME $IPMI_PASSWORD'
+command=/opt/kvm-console/bin/viewer-app.sh
 user=kvm-console
 autostart=false
 autorestart=true
 stopsignal=QUIT
 environment=DISPLAY=":1",HOME="/home/kvm-console"
-stdout_logfile=/var/log/ikvm-viewer.log
+stdout_logfile=/var/log/viewer-app.log
 redirect_stderr=true
 

--- a/opt/kvm-console/bin/viewer-app.sh
+++ b/opt/kvm-console/bin/viewer-app.sh
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ip_address="$1"
-username=${2:-ADMIN}
-password=${3:-ADMIN}
+ip_address="${IPMI_ADDRESS}"
+username=${IPMI_USERNAME:-ADMIN}
+password=${IPMI_PASSWORD:-ADMIN}
 
 get_session_id() {
   local login_url="${proto}://${ip_address}/cgi/login.cgi"


### PR DESCRIPTION
The ikvm-viewer service is renamed for viewer-app in order to support
more than ikvm without having to create new services or groups.  This
would be the name of this service if there was a base image.

The next step would be to extract everything non related to ikvm in
another project and only keep here what is specific to the Supermicro
IPMI console.
